### PR TITLE
Use puppeteer-core instead of puppeteer

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,4 +1,4 @@
-import { Page, launch, Browser, LaunchOptions } from "puppeteer";
+import { Page, launch, Browser, LaunchOptions } from "puppeteer-core";
 import { JQueryAble, IJQueryAble } from './jQueryPlugin';
 
 /**


### PR DESCRIPTION
Hey,
My first pull request on GitHub, not sure to do it right !
I'm using your npm package in a project which does not use puppeteer itself but puppeteer-core.
It order to reduce the dependencies I tried to use only puppeteer-core in puppeteer-jquery, and for my usage it works as well.
Perpahs it does not work well for all usage tho.
Anyway have a good day,
Félix.